### PR TITLE
Add SessionAuthenticationMiddleware to MIDDLEWARE_CLASSES

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
@@ -61,6 +61,7 @@ class Common(Configuration):
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
     )


### PR DESCRIPTION
It’s included if settings.py was generated by startproject on Django ≥ 1.7. 
http://goo.gl/s2y3mB